### PR TITLE
docs: standardize benchmark name to "First Do NOHARM"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository provides instructions and test files to validate your custom mod
 ```
 mast/
 ├── benchmarks/
-│   ├── donoharm/               # Do No Harm benchmark
+│   ├── donoharm/               # First Do NOHARM benchmark
 │   │   ├── prompts/            # System prompt variants (default.md sent with each case)
 │   │   ├── schema.json         # Response validation schema
 │   │   ├── validator.py        # API testing logic

--- a/docs/benchmark_descriptions.md
+++ b/docs/benchmark_descriptions.md
@@ -2,10 +2,10 @@
 
 This document provides detailed descriptions of all benchmarks in the MAST leaderboard.
 
-## Do No Harm Benchmark
+## First Do NOHARM Benchmark
 
 ### Purpose
-Do No Harm is a physician-validated medical benchmark to evaluate the safety and completeness of AI-generated clinical management plans. Models are presented with real clinical cases and asked to provide free-text management plans, which are then scored by multiple LLM judges against physician-authored rubrics. The benchmark covers cases across multiple medical specialties with perturbations testing robustness to variations in patient demographics, lab values, and clinical context. This project is led and supported by the ARISE AI Research Network, based at Stanford and Harvard.
+First Do NOHARM is a physician-validated medical benchmark to evaluate the safety and completeness of AI-generated clinical management plans. Models are presented with real clinical cases and asked to provide free-text management plans, which are then scored by multiple LLM judges against physician-authored rubrics. The benchmark covers cases across multiple medical specialties with perturbations testing robustness to variations in patient demographics, lab values, and clinical context. This project is led and supported by the ARISE AI Research Network, based at Stanford and Harvard.
 
 Read our [study](https://arxiv.org/abs/2512.01241) for more details.
 See the live [leaderboard](https://benchmarks.arise-ai.org/) for current rankings.


### PR DESCRIPTION
Renames the flagship benchmark from "Do No Harm" to the canonical "First Do NOHARM" in README.md and docs/benchmark_descriptions.md, matching the apps and leaderboard.

Directory/id `donoharm/` and the published paper citation title are left unchanged.