### PR TITLE
docs: refresh public copy and restructure README benchmark tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MAST (Medical AI Superintelligence Test) is a medical AI benchmarking system. Submitters provide an API endpoint that gets tested against standardized medical scenarios. Results appear on the leaderboard at benchmarks.arise-ai.org.
+MAST (Medical AI Superintelligence Test) is a medical AI benchmarking system. Submitters provide an API endpoint that gets tested against standardized medical scenarios. Results appear on the leaderboard at arise-ai.org/mast/technical.
 
 The system sends HTTPS POST requests with clinical prompts to submitter APIs, validates JSON responses against schemas, and saves results for audit.
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The `response` field must contain at least 50 characters of clinical text. There
 
 ## Benchmarks
 
-The MAST suite spans the clinical capabilities measured on the public [leaderboard](https://arise-ai.org/mast/technical). Each benchmark links to code, data, or a site so you can run it yourself (the First Do NOHARM kit is coming shortly). Full descriptions and demos: [arise-ai.org/mast/benchmarks](https://arise-ai.org/mast/benchmarks).
+The MAST suite spans the clinical capabilities measured on the public [leaderboard](https://arise-ai.org/mast/technical). Each benchmark links to its code, data, or site (the First Do NOHARM kit is coming shortly). Full descriptions and demos: [arise-ai.org/mast/benchmarks](https://arise-ai.org/mast/benchmarks).
 
-| Benchmark | Clinical capability | Run it yourself | Paper |
+| Benchmark | Clinical capability | Code / data | Paper |
 | --- | --- | --- | --- |
 | First Do NOHARM v2 | Safety, management reasoning | Coming soon | [arXiv](https://arxiv.org/abs/2512.01241) |
 | Script Concordance Test (SCT) | Reasoning under uncertainty | [`benchmarks/sct/`](benchmarks/sct/) | [NEJM AI](https://ai.nejm.org/doi/full/10.1056/AIdbp2500120) |
@@ -104,6 +104,8 @@ The MAST suite spans the clinical capabilities measured on the public [leaderboa
 | PhysicianBench | Agentic EHR tasks | [GitHub](https://github.com/HealthRex/PhysicianBench) | - |
 | ReXrank Mini | Multimodal radiology | [GitHub](https://github.com/rajpurkarlab/ReXrank) | [arXiv](https://arxiv.org/abs/2411.15122) |
 | Multimodal Images | Multimodal dermatology | [DDI](https://ddi-dataset.github.io/) · [MIDAS](https://stanfordaimi.azurewebsites.net/datasets/f4c2020f-801a-42dd-a477-a1a8357ef2a5) | [DDI](https://www.science.org/doi/10.1126/sciadv.abq6147) · [MIDAS](https://ai.nejm.org/doi/full/10.1056/AIdbp2400732) |
+
+ReXrank Mini is MAST's curated subset of the full [ReXrank](https://github.com/rajpurkarlab/ReXrank) benchmark, run with that harness.
 
 - **First Do NOHARM v2**: free-text management plans reconstructed from real generalist-to-specialist consults, scored by multiple LLM judges against specialist-authored rubrics. The `benchmarks/donoharm/` validator checks your endpoint's response format (see [API Request Format](#api-request-format) above); a full run-it-yourself kit is coming shortly.
 - **Script Concordance Test (SCT)**: probabilistic clinical reasoning under uncertainty. Run it yourself on the 174-item open subset with deterministic scoring (no LLM judge); see `benchmarks/sct/README.md` for setup, the `sct_score` metric, and reference scores.
@@ -131,20 +133,20 @@ pip install jsonschema requests
 
 ### Resource Requirements
 
-Estimated tokens and inference cost per benchmark for a full run, measured from a GPT-5.5 evaluation. Output tokens include reasoning tokens; both output volume and cost scale with reasoning effort and your provider's pricing.
+Token and inference-cost estimates per benchmark, from a single GPT-5.5 reference run. Treat these as a rough guide only: your model's token counts and cost will differ, often substantially. Output tokens include reasoning tokens; both scale with reasoning effort and your provider's pricing.
 
-| Benchmark | Tasks | Input tokens | Output tokens | Est. cost (GPT-5.5) |
-| --- | --- | --- | --- | --- |
-| First Do NOHARM v2 | 1,100 | 0.7M | 0.9M | $31 |
-| Script Concordance Test (SCT) | 750 | 0.2M | 0.2M | $6 |
-| CPC-Bench | 2,539 | 5.6M | 2.2M | $87 |
-| MedAgentBench v2 | 300 | 12.5M | 0.4M | $74 |
-| PhysicianBench | 100 | 36.6M | 0.7M | $205 |
-| ReXrank Mini | 3,112 | 32.9M | 2.0M | $221 |
-| Multimodal Images | 3,508 | 32.0M | 1.0M | $191 |
-| **Full suite** | **11,409** | **~121M** | **~7.4M** | **~$815** |
+| Benchmark | Input tokens | Output tokens | Est. cost (GPT-5.5) |
+| --- | --- | --- | --- |
+| First Do NOHARM v2 | 0.7M | 0.9M | $31 |
+| Script Concordance Test (SCT) | 0.2M | 0.2M | $6 |
+| CPC-Bench | 5.6M | 2.2M | $87 |
+| MedAgentBench v2 | 12.5M | 0.4M | $74 |
+| PhysicianBench | 36.6M | 0.7M | $205 |
+| ReXrank Mini | 32.9M | 2.0M | $221 |
+| Multimodal Images | 32.0M | 1.0M | $191 |
+| **Full suite** | **~121M** | **~7.4M** | **~$815** |
 
-Agentic benchmarks (MedAgentBench, PhysicianBench) consume far more input tokens because each task spans many tool-use turns. Costs cover model inference only; LLM-judge scoring is run by the MAST team. PhysicianBench reflects the GPT-5.5 high-effort run (the complete 100-task run available).
+Agentic benchmarks (MedAgentBench, PhysicianBench) consume far more input tokens because each task spans many tool-use turns. Costs cover model inference only; LLM-judge scoring is run by the MAST team. PhysicianBench reflects the GPT-5.5 high-effort run.
 
 ## File Formats
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 MAST (Medical AI Superintelligence Test) is a suite of clinically realistic benchmarks to evaluate real-world medical capabilities of artificial intelligence models. The system provides a leaderboard where AI models submit API endpoints that are automatically tested against standardized medical scenarios. 
 
-The live leaderboard is available at [benchmarks.arise-ai.org](https://benchmarks.arise-ai.org).
+The live leaderboard is available at [arise-ai.org/mast/technical](https://arise-ai.org/mast/technical).
 
 This repository provides instructions and test files to validate your custom model API endpoint. After passing validation, view the [Submission Agreement](docs/submission_agreement.md) and submit the [Registration Form](https://forms.gle/4exSPLbsmWjNmMRQ7) for review by the MAST team. The API and token are used only for benchmark execution and are not stored after evaluation.
 
@@ -51,7 +51,7 @@ git clone https://github.com/ARISENetwork/mast.git
 cd mast
 ```
 
-2. **Set up your API endpoint** — provide a hosted endpoint for accessing and benchmarking your model.
+2. **Set up your API endpoint**: provide a hosted endpoint for accessing and benchmarking your model.
 
 3. **Configure your endpoint** by copying and editing the config:
 ```bash
@@ -87,24 +87,26 @@ APIs must return a JSON object containing a free-text clinical management plan:
 }
 ```
 
-The `response` field must contain at least 50 characters of clinical text. There is no required structure within the text itself — the model should write a management plan as described in the prompt. See `benchmarks/donoharm/outputs/test_001.txt` for an example of a valid response.
+The `response` field must contain at least 50 characters of clinical text. There is no required structure within the text itself; the model should write a management plan as described in the prompt. See `benchmarks/donoharm/outputs/test_001.txt` for an example of a valid response.
 
 **OpenAI-compatible endpoints** are also accepted. If your API returns the standard OpenAI chat completions format (`choices[0].message.content`), the validator will automatically extract the content. This includes endpoints served via OpenRouter or any OpenAI-compatible provider.
 
 ## Benchmarks
 
-### First Do NOHARM Benchmark
+The MAST suite spans the clinical capabilities measured on the public [leaderboard](https://arise-ai.org/mast/technical). Each benchmark links to code, data, or a site so you can run it yourself (the First Do NOHARM kit is coming shortly). Full descriptions and demos: [arise-ai.org/mast/benchmarks](https://arise-ai.org/mast/benchmarks).
 
-- **Study**: https://arxiv.org/abs/2512.01241
-- **Task**: Provide clinical recommendations for a medical case
-- **Input**: Reconstructed from real clinical cases, where a generalist physician electronically consulted a specialist/subspecialist
-- **Output**: Free-text management plan (assessment + recommendations)
-- **Scoring**: Evaluated by multiple LLM judges against specialist-authored rubrics
-- **Validation**: Format compliance (schema validation only)
+| Benchmark | Clinical capability | Run it yourself | Paper |
+| --- | --- | --- | --- |
+| First Do NOHARM v2 | Safety, management reasoning | Coming soon | [arXiv](https://arxiv.org/abs/2512.01241) |
+| Script Concordance Test (SCT) | Reasoning under uncertainty | [`benchmarks/sct/`](benchmarks/sct/) | [NEJM AI](https://ai.nejm.org/doi/full/10.1056/AIdbp2500120) |
+| CPC-Bench | Diagnostic reasoning | [cpcbench.com](https://cpcbench.com) | [arXiv](https://arxiv.org/abs/2509.12194) |
+| MedAgentBench v2 | Agentic EHR tasks | [GitHub](https://github.com/ARISENetwork/medagentbenchv2) | [Paper](https://psb.stanford.edu/psb-online/proceedings/psb26/chen_eric.pdf) |
+| PhysicianBench | Agentic EHR tasks | [GitHub](https://github.com/HealthRex/PhysicianBench) | - |
+| ReXrank Mini | Multimodal radiology | [GitHub](https://github.com/rajpurkarlab/ReXrank) | [arXiv](https://arxiv.org/abs/2411.15122) |
+| Multimodal Images | Multimodal dermatology | [DDI](https://ddi-dataset.github.io/) · [MIDAS](https://stanfordaimi.azurewebsites.net/datasets/f4c2020f-801a-42dd-a477-a1a8357ef2a5) | [DDI](https://www.science.org/doi/10.1126/sciadv.abq6147) · [MIDAS](https://ai.nejm.org/doi/full/10.1056/AIdbp2400732) |
 
-### SCT (Script Concordance Test) Benchmark
-
-*Coming soon.* See `benchmarks/sct/README.md` for preliminary details.
+- **First Do NOHARM v2**: free-text management plans reconstructed from real generalist-to-specialist consults, scored by multiple LLM judges against specialist-authored rubrics. The `benchmarks/donoharm/` validator checks your endpoint's response format (see [API Request Format](#api-request-format) above); a full run-it-yourself kit is coming shortly.
+- **Script Concordance Test (SCT)**: probabilistic clinical reasoning under uncertainty. Run it yourself on the 174-item open subset with deterministic scoring (no LLM judge); see `benchmarks/sct/README.md` for setup, the `sct_score` metric, and reference scores.
 
 ## Validation Results
 
@@ -125,18 +127,24 @@ pip install jsonschema requests
 - **Concurrent requests**: Must support 5-10 simultaneous connections
 - **Authentication**: Bearer token authentication required
 - **Response time**: Under 300 seconds per request
-- **Response format**: Valid JSON — either `{"response": "..."}` or OpenAI-compatible chat completions format
+- **Response format**: Valid JSON: either `{"response": "..."}` or OpenAI-compatible chat completions format
 
 ### Resource Requirements
 
-#### Estimated Token Usage
-- Input tokens: ~1,500,000
-- Output tokens: ~3,000,000-18,000,000 (varies with reasoning depth)
+Estimated tokens and inference cost per benchmark for a full run, measured from a GPT-5.5 evaluation. Output tokens include reasoning tokens; both output volume and cost scale with reasoning effort and your provider's pricing.
 
-#### Estimated Costs
-Approximate inference costs for large frontier-scale models: **$125-$400** for a full benchmark run (but can be higher depending on reasoning effort).
+| Benchmark | Tasks | Input tokens | Output tokens | Est. cost (GPT-5.5) |
+| --- | --- | --- | --- | --- |
+| First Do NOHARM v2 | 1,100 | 0.7M | 0.9M | $31 |
+| Script Concordance Test (SCT) | 750 | 0.2M | 0.2M | $6 |
+| CPC-Bench | 2,539 | 5.6M | 2.2M | $87 |
+| MedAgentBench v2 | 300 | 12.5M | 0.4M | $74 |
+| PhysicianBench | 100 | 36.6M | 0.7M | $205 |
+| ReXrank Mini | 3,112 | 32.9M | 2.0M | $221 |
+| Multimodal Images | 3,508 | 32.0M | 1.0M | $191 |
+| **Full suite** | **11,409** | **~121M** | **~7.4M** | **~$815** |
 
-*Costs are approximate and depend on your provider's current pricing. The benchmark is run at multiple response lengths for sensitivity analysis. Reasoning models produce significantly more output tokens due to chain-of-thought, increasing costs substantially.*
+Agentic benchmarks (MedAgentBench, PhysicianBench) consume far more input tokens because each task spans many tool-use turns. Costs cover model inference only; LLM-judge scoring is run by the MAST team. PhysicianBench reflects the GPT-5.5 high-effort run (the complete 100-task run available).
 
 ## File Formats
 

--- a/benchmarks/sct/README.md
+++ b/benchmarks/sct/README.md
@@ -78,7 +78,7 @@ The full benchmark includes 750 questions from 10 medical institutions; this bun
 
 ## Submitting to the leaderboard (optional)
 
-If you want your model on the public [leaderboard](https://benchmarks.arise-ai.org), your hosted API endpoint must first pass a format check, then you register it. See [`submission/`](submission/) for the endpoint validator and the 5 calibration cases, and `docs/submission_agreement.md` (repo root) for the Registration Form and terms. This step is only for leaderboard submission; it is not needed to run the benchmark yourself.
+If you want your model on the public [leaderboard](https://arise-ai.org/mast/technical), your hosted API endpoint must first pass a format check, then you register it. See [`submission/`](submission/) for the endpoint validator and the 5 calibration cases, and `docs/submission_agreement.md` (repo root) for the Registration Form and terms. This step is only for leaderboard submission; it is not needed to run the benchmark yourself.
 
 ## License
 

--- a/docs/benchmark_descriptions.md
+++ b/docs/benchmark_descriptions.md
@@ -1,6 +1,6 @@
 # Benchmark Descriptions
 
-This document provides detailed descriptions of all benchmarks in the MAST leaderboard.
+This document provides detailed descriptions of the benchmarks with runnable kits in this repository. The full MAST suite on the public leaderboard also includes CPC-Bench (diagnostic reasoning), MedAgentBench v2 and PhysicianBench (agentic EHR tasks), ReXrank Mini (radiology), and Multimodal Images (dermatology); see [arise-ai.org/mast/benchmarks](https://arise-ai.org/mast/benchmarks) for the complete set.
 
 ## First Do NOHARM Benchmark
 
@@ -8,7 +8,7 @@ This document provides detailed descriptions of all benchmarks in the MAST leade
 First Do NOHARM is a physician-validated medical benchmark to evaluate the safety and completeness of AI-generated clinical management plans. Models are presented with real clinical cases and asked to provide free-text management plans, which are then scored by multiple LLM judges against physician-authored rubrics. The benchmark covers cases across multiple medical specialties with perturbations testing robustness to variations in patient demographics, lab values, and clinical context. This project is led and supported by the ARISE AI Research Network, based at Stanford and Harvard.
 
 Read our [study](https://arxiv.org/abs/2512.01241) for more details.
-See the live [leaderboard](https://benchmarks.arise-ai.org/) for current rankings.
+See the live [leaderboard](https://arise-ai.org/mast/technical) for current rankings.
 
 ### Input Format
 - **File type:** Plain text (.txt)
@@ -39,7 +39,19 @@ Models are scored by multiple LLM judges against physician-authored rubrics. Key
 
 ## SCT (Script Concordance Test) Benchmark
 
-*Coming soon.* See `benchmarks/sct/README.md` for preliminary details.
+### Purpose
+The Script Concordance Test measures probabilistic clinical reasoning under uncertainty. Given a clinical scenario, a hypothesis (diagnosis or treatment), and a new piece of information, the model rates how that information shifts the likelihood of the hypothesis on a 5-point scale (-2 to +2). Responses are scored against expert physician panel distributions.
+
+### Run it yourself
+SCT ships as a run-it-yourself kit over a 174-item open subset (Adelaide SCT + Open Medical SCT) with deterministic scoring (no LLM judge). The headline metric is `sct_score`: alignment with the expert consensus distribution, scaled 0 to 1, with an item-level bootstrap confidence interval. See `benchmarks/sct/README.md` for setup, reference scores, and data provenance.
+
+### Output Format
+- **File type:** JSON (.json)
+- **Required fields:** `Rating` (integer, -2 to +2) and `Rationale` (string)
+- **Also accepted:** OpenAI-compatible chat completions format (content is extracted automatically)
+
+### Submission
+Submitting to the public leaderboard is optional and separate from running the benchmark locally. See `benchmarks/sct/submission/` for the endpoint validator and calibration cases.
 
 ## Adding New Benchmarks
 When adding new benchmarks:


### PR DESCRIPTION
Refreshes the public repo copy to match the canonical names/URLs the other ARISE repos now use, and restructures the README benchmark info into tables.

## Changes
- **Canonical leaderboard URL**: `benchmarks.arise-ai.org` -> `arise-ai.org/mast/technical` across README, docs, and CLAUDE.md (the old host 308-redirects there).
- **SCT marked as shipped**: dropped "coming soon"; it now points to the run-it-yourself kit in `benchmarks/sct/`.
- **Benchmarks table**: replaced the NOHARM-centric prose with a suite-wide table (7 benchmarks) with a `Code / data` link per benchmark and a separate `Paper` column. NOHARM's run link is marked "Coming soon" pending its kit.
- **Per-benchmark resource table**: replaced the single aggregate token/cost estimate with per-benchmark tokens + cost measured from a GPT-5.5 reference run, framed as a rough guide only.
- **ReXrank**: clarified that "ReXrank Mini" is MAST's curated subset run on the full ReXrank harness.
- Removed em-dashes from the README.

## Notes
- Per-benchmark figures come from a single GPT-5.5 run; exact per-benchmark task counts were intentionally omitted to avoid signaling private test-set sizes.
- "MAST team" is used for operational review (canonical); "Steering Committee" stays reserved for governance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)