### PR TITLE
chore(deps): bump litellm to >=1.84.0 (GHSA-4xpc-pv4p-pm3w)

### DIFF
--- a/benchmarks/donoharm/requirements.txt
+++ b/benchmarks/donoharm/requirements.txt
@@ -1,5 +1,5 @@
 # Requires Python >= 3.10
-litellm>=1.83.0,<1.84
+litellm>=1.84.0,<1.85
 google-genai>=2,<3
 jsonschema>=4.0,<5
 numpy>=2.0,<3

--- a/benchmarks/sct/requirements.txt
+++ b/benchmarks/sct/requirements.txt
@@ -1,4 +1,4 @@
-litellm>=1.83.0,<1.84
+litellm>=1.84.0,<1.85
 numpy>=2.0,<3
 pandas>=2.2,<3
 pyyaml>=6.0.3,<7


### PR DESCRIPTION
Closes critical Dependabot alerts #49 (sct) and #50 (donoharm).

- **Advisory**: GHSA-4xpc-pv4p-pm3w, LiteLLM auth bypass via Host Header Injection (critical), `litellm < 1.84.0`, patched in `1.84.0`.
- **Change**: pin bumped `>=1.83.0,<1.84` -> `>=1.84.0,<1.85` in `benchmarks/donoharm/requirements.txt` and `benchmarks/sct/requirements.txt`.

Both bundles use litellm only as a client library (calling model APIs); neither runs the litellm proxy server where this vuln lives, so practical exposure was nil. This is hygiene to clear the alerts.